### PR TITLE
Change doc-viewer to use new notion handbook

### DIFF
--- a/src/app/home.js
+++ b/src/app/home.js
@@ -53,7 +53,7 @@ const TextWithLink = ({descriptionBefore, descriptionAfter, link, linkText}) => 
       descriptionAfter,
     ])
 
-export default (menu, {descriptionBefore, descriptionAfter, link, linkText}) => r(
+export default (menu, notionLinkProps) => r(
   ['div', null,
     ['div', {className: 'line'}],
     ['div', {className: 'wrapper'},
@@ -65,6 +65,6 @@ export default (menu, {descriptionBefore, descriptionAfter, link, linkText}) => 
       ['section', {className: 'cards'},
         ...menu.map((item, index) => [MenuItem, {key: index, item}]),
       ],
-      ['section', {className: 'text_with_link'}, [TextWithLink, {descriptionBefore, descriptionAfter, link, linkText}]],
+      ['section', {className: 'text_with_link'}, [TextWithLink, notionLinkProps]],
     ],
   ])

--- a/src/app/home.js
+++ b/src/app/home.js
@@ -46,14 +46,14 @@ const MenuItem = ({item}) => r(
     item.submenu && [SubMenu, {items: item.submenu}],
   ])
 
-const Text = ({textWithLink}) => r(
+const TextWithLink = ({descriptionBefore, descriptionAfter, link, linkText}) => r(
     ['p', {className: 'text__wrapper'},
-      textWithLink.descriptionBefore,
-      ['a', {href:textWithLink.link ?? '', className:'link__text'}, textWithLink.linkText],
-      textWithLink.descriptionAfter,
+      descriptionBefore,
+      ['a', {href:link ?? '', className:'link__text'}, linkText],
+      descriptionAfter,
     ])
 
-export default (menu, textWithLink) => r(
+export default (menu, {descriptionBefore, descriptionAfter, link, linkText}) => r(
   ['div', null,
     ['div', {className: 'line'}],
     ['div', {className: 'wrapper'},
@@ -65,6 +65,6 @@ export default (menu, textWithLink) => r(
       ['section', {className: 'cards'},
         ...menu.map((item, index) => [MenuItem, {key: index, item}]),
       ],
-      ['section', {className: 'text_with_link'}, [Text, {textWithLink}]],
+      ['section', {className: 'text_with_link'}, [TextWithLink, {descriptionBefore, descriptionAfter, link, linkText}]],
     ],
   ])

--- a/src/app/home.js
+++ b/src/app/home.js
@@ -46,7 +46,14 @@ const MenuItem = ({item}) => r(
     item.submenu && [SubMenu, {items: item.submenu}],
   ])
 
-export default (menu) => r(
+const Text = ({textWithLink}) => r(
+    ['p', {className: 'text__wrapper'},
+      textWithLink.descriptionBefore,
+      ['a', {href:textWithLink.link ?? '', className:'link__text'}, textWithLink.linkText],
+      textWithLink.descriptionAfter,
+    ])
+
+export default (menu, textWithLink) => r(
   ['div', null,
     ['div', {className: 'line'}],
     ['div', {className: 'wrapper'},
@@ -58,5 +65,6 @@ export default (menu) => r(
       ['section', {className: 'cards'},
         ...menu.map((item, index) => [MenuItem, {key: index, item}]),
       ],
+      ['section', {className: 'text_with_link'}, [Text, {textWithLink}]],
     ],
   ])

--- a/src/app/html.js
+++ b/src/app/html.js
@@ -1,9 +1,9 @@
 import {renderToString} from 'react-dom/server.js'
 import home from './home.js'
 
-export default ({style, menu, config, linkText}) => {
+export default ({style, menu, config, notionLinkProps}) => {
   config = config ?? {title: 'Handbook'}
-  const html = renderToString(home(menu, linkText))
+  const html = renderToString(home(menu, notionLinkProps))
 
   return `
         <html lang="en">

--- a/src/app/html.js
+++ b/src/app/html.js
@@ -1,9 +1,9 @@
 import {renderToString} from 'react-dom/server.js'
 import home from './home.js'
 
-export default ({style, menu, config}) => {
+export default ({style, menu, config, linkText}) => {
   config = config ?? {title: 'Handbook'}
-  const html = renderToString(home(menu))
+  const html = renderToString(home(menu, linkText))
 
   return `
         <html lang="en">

--- a/src/doc.js
+++ b/src/doc.js
@@ -79,9 +79,9 @@ export const oldHome = async () => {
   const menu     = (await load('old_menu.json')) ?? 'null'
   const config   = (await load('config.json'))   ?? 'null'
   const style    = (await load('old_style.css')) ?? defaultStyle
-  const linkText = 'null'
+  const notionLinkProps = 'null'
 
-  return {menu: JSON.parse(menu), config: JSON.parse(config), style, linkText}
+  return {menu: JSON.parse(menu), config: JSON.parse(config), style, notionLinkProps}
 } 
 
 export const home = async () => {
@@ -92,9 +92,9 @@ export const home = async () => {
   const menu     = (await load('menu.json'))   ?? 'null'
   const config   = (await load('config.json')) ?? 'null'
   const style    = (await load('style.css'))   ?? defaultStyle
-  const linkText = (await load('text.json'))   ?? 'null'
+  const notionLinkProps = (await load('text.json'))   ?? 'null'
 
-  return {menu: JSON.parse(menu), config: JSON.parse(config), style, linkText: JSON.parse(linkText)}
+  return {menu: JSON.parse(menu), config: JSON.parse(config), style, notionLinkProps: JSON.parse(notionLinkProps)}
 }
 
 const alias = async ({docId, name}) => {

--- a/src/doc.js
+++ b/src/doc.js
@@ -71,16 +71,30 @@ const setHome = async (param, body, req) => {
   return http.ok
 }
 
+export const oldHome = async () => {
+  const load = async (name) => (await loadFile(c.homePath, name))
+                               ?.Body
+                               ?.toString()
+
+  const menu     = (await load('old_menu.json')) ?? 'null'
+  const config   = (await load('config.json'))   ?? 'null'
+  const style    = (await load('old_style.css')) ?? defaultStyle
+  const linkText = 'null'
+
+  return {menu: JSON.parse(menu), config: JSON.parse(config), style, linkText}
+} 
+
 export const home = async () => {
   const load = async (name) => (await loadFile(c.homePath, name))
                                ?.Body
                                ?.toString()
 
-  const menu   = (await load('menu.json'))   ?? 'null'
-  const config = (await load('config.json')) ?? 'null'
-  const style  = (await load('style.css'))   ?? defaultStyle
+  const menu     = (await load('menu.json'))   ?? 'null'
+  const config   = (await load('config.json')) ?? 'null'
+  const style    = (await load('style.css'))   ?? defaultStyle
+  const linkText = (await load('text.json'))   ?? 'null'
 
-  return {menu: JSON.parse(menu), config: JSON.parse(config), style}
+  return {menu: JSON.parse(menu), config: JSON.parse(config), style, linkText: JSON.parse(linkText)}
 }
 
 const alias = async ({docId, name}) => {

--- a/src/index.js
+++ b/src/index.js
@@ -28,6 +28,8 @@ http.register(app, '/\\$auth', auth.routes)
 
 // Home Page
 app.get('/', auth.authorize, async (req, res) => res.send(html(await doc.home())))
+// Old homepage
+app.get('/old/', auth.authorize, async (req, res) => res.send(html(await doc.oldHome())))
 
 // Has to be the last one, otherwise it would match all other routes.
 http.register(app, null, doc.routes)


### PR DESCRIPTION
Doc-viewer now links to new notion handbook and also to the old one.
This is to discourage the use of the old handbook but in the case there
are people who still wants to use them, they can.

There is still a need to upload files to s3 server before the merge of this PR